### PR TITLE
Note regarding where (not) to store arduino-serial.c

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,6 +37,8 @@ The following C program `arduino-serial` is recommended for this task. It can be
 
 * [arduino-serial.c](http://todbot.com/blog/2006/12/06/arduino-serial-c-code-to-talk-to-arduino)
 
+NOTE: Don't put `arduino-serial.c` into your `Arduino/libraries/CmdMessenger/` directory or CmdMessenger won't compile anymore.
+
 We provide a Max5 / MaxMSP example (`/Max5` folder) because historically that has been included with previous distributions of Messenger. The inclusion of a MaxMSP sample is not any kind of recommendation over other languages however.
 
 Dreamcat4


### PR DESCRIPTION
Hi dreamcat4,

Following your instructions in the README, I downloaded arduino-serial.c to use with CmdMessenger. Since I am an Arduino beginner, I was unaware of how the library tool chain works. I put the .c file in the same directory as CmdMessenger.cpp, thinking I'd keep similar things together for future reference. Because arduino-serial.c uses the Unix header files not needed for Arduino, the build process failed miserably.

I added a small note to your README file to remind others not to put this .c file in the Arduino 3rd party library path.
